### PR TITLE
do not serialize to_one data when type is not available from source

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -355,9 +355,10 @@ module JSONAPI
     def to_one_linkage(source, relationship)
       linkage = {}
       linkage_id = foreign_key_value(source, relationship)
+      linkage_type = format_key(relationship.type_for_source(source))
 
-      if linkage_id
-        linkage[:type] = format_key(relationship.type_for_source(source))
+      if linkage_id && linkage_type.present?
+        linkage[:type] = linkage_type
         linkage[:id] = linkage_id
       else
         linkage = nil


### PR DESCRIPTION
@gkorban  @cesarizu This is more of a patch than a fix but this fixes the problem where the serialized data "type" is empty due to a deleted to_one relationship. 

```json
"data": {
  "type": "",
  "id": "53179df984e798c615000151"
}
```

