### PR TITLE
fixes for supporting to_many updates and polymorphism

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -435,7 +435,12 @@ module JSONAPI
               checked_to_one_relationships[param] = parse_to_one_relationship(link_value, relationship)
             elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
               parse_to_many_relationship(link_value, relationship) do |result_val|
-                checked_to_many_relationships[param] = result_val
+                #for polymorphic updates
+                if checked_to_many_relationships[param]
+                  checked_to_many_relationships[param] = checked_to_many_relationships[param].concat(result_val)
+                else
+                  checked_to_many_relationships[param] = result_val
+                end
               end
             end
           end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -764,7 +764,7 @@ module JSONAPI
         context = options[:context]
         records = records(options)
         records = apply_includes(records, options)
-        models = records.where({_primary_key => keys})
+        models = records.in({_primary_key => keys})
         models.collect do |model|
           self.resource_for_model(model).new(model, context)
         end


### PR DESCRIPTION
@gkorban @cesarizu I bumped into a few issues while working on updating to_many relationships. Specifically this https://github.com/cerebris/jsonapi-resources/issues/118 and the other changes to `request_parser.rb` are because of a problem where polymorphic updates would become inconsistent if more than one type was added.